### PR TITLE
set default llm to gpt-3.5-turbo as it's not on beta as gpt-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use OpenAI's Language Learning Models (LLMs), you can set your OpenAI secret 
 ```bash
 export OPENAI_API_KEY='sk-...'
 ```
-By default, the `SparkAI` instances will use the GPT-4 model. However, you're encouraged to experiment with creating and implementing other LLMs, which can be passed during the initialization of `SparkAI` instances for various use-cases.
+By default, the `SparkAI` instances will use the GPT 3.5 (gpt-3.5-turbo). However, you're encouraged to experiment with creating and implementing other LLMs, which can be passed during the initialization of `SparkAI` instances for various use-cases.
 
 ## Usage
 ### Initialization

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -65,7 +65,7 @@ class SparkAI:
         """
         self._spark = spark_session or SparkSession.builder.getOrCreate()
         if llm is None:
-            llm = ChatOpenAI(model_name='gpt-4', temperature=0)
+            llm = ChatOpenAI(model_name='gpt-3.5-turbo', temperature=0)
         self._llm = llm
         self._web_search_tool = web_search_tool or self._default_web_search_tool
         if enable_cache:


### PR DESCRIPTION
gpt-4 is in beta so it probably makes sense use gpt-3.5-turbo. If it doesn't make sense would be interesting know what limitations you may have found with it.

Referred in #46  