### PR TITLE
Modify logger handler limit to one per session

### DIFF
--- a/pyspark_ai/code_logger.py
+++ b/pyspark_ai/code_logger.py
@@ -19,9 +19,10 @@ class CodeLogger:
     def __init__(self, name):
         self.logger = logging.getLogger(name)
         self.logger.setLevel(logging.INFO)
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(CustomFormatter("%(message)s"))  # output only the message
-        self.logger.addHandler(handler)
+        if not self.logger.handlers:
+            handler = logging.StreamHandler(sys.stdout)
+            handler.setFormatter(CustomFormatter("%(message)s"))  # output only the message
+            self.logger.addHandler(handler)
 
     @staticmethod
     def colorize_code(code, language):


### PR DESCRIPTION
Hi Team,

It's better to limit the logger handler to one per session. As user might want to use multiple llm in a single session.
Currently that would result in multiple same logs printed on the console.

Code Block:
`from pyspark_ai import SparkAI
spark_ai=SparkAI(verbose=True)
spark_ai=SparkAI(verbose=True)
spark_ai=SparkAI(verbose=True)
spark_ai.activate()`

<img width="534" alt="Screenshot 2023-07-01 at 3 50 52 AM" src="https://github.com/databrickslabs/pyspark-ai/assets/91727885/e8bb8957-c28e-495e-b9c1-2f94940250e5">

Limiting the handler will result in just one log.
