### PR TITLE
[Minor] Improve error messages for codegen

### DIFF
--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -376,8 +376,11 @@ class SparkAI:
         )
         self.log(response)
         codeblocks = self._extract_code_blocks(response)
-        for code in codeblocks:
-            exec(code)
+        code = "\n".join(codeblocks)
+        try:
+            exec(compile(code, "plot_df-CodeGen", "exec"))
+        except Exception as e:
+            raise Exception("Could not evaluate Python code", e)
 
     def verify_df(self, df: DataFrame, desc: str, cache: bool = True) -> None:
         """
@@ -393,8 +396,10 @@ class SparkAI:
         self.log(f"Generated code:\n{formatted_code}")
 
         locals_ = {}
-        exec(llm_output, {"df": df}, locals_)
-
+        try:
+            exec(compile(llm_output, "verify_df-CodeGen", "exec"), {"df": df}, locals_)
+        except Exception as e:
+            raise Exception("Could not evaluate Python code", e)
         self.log(f"\nResult: {locals_['result']}")
 
     def udf(self, func: Callable) -> Callable:
@@ -417,8 +422,10 @@ class SparkAI:
         self.log(f"Creating following Python UDF:\n{formatted_code}")
 
         locals_ = {}
-        exec(code, globals(), locals_)
-
+        try:
+            exec(compile(code, "udf-CodeGen", "exec"), globals(), locals_)
+        except Exception as e:
+            raise Exception("Could not evaluate Python code", e)
         return locals_[udf_name]
 
     def activate(self):


### PR DESCRIPTION
When Python code is evaluated, currently it uses plain `exec()` calls. This patch improves the system by wrapping the `exec()` call with a `try-except` block and wrapping the generated code with a `compile()` call. This will give better error messages.

For example using compile with a virtual filename lets the user better identify where the errors come from.

```
❯ python
Python 2.7.18 (v2.7.18:8d21aa21f2, Apr 19 2020, 20:48:48)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> compile("false", "Pyspark", "exec")
<code object <module> at 0x7faa281253b0, file "Pyspark", line 1>
>>> exec(compile("false", "Pyspark", "exec"))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  --> File "Pyspark", line 1, in <module>
NameError: name 'false' is not defined
```

