### PR TITLE
Removing restrictive dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1869,4 +1869,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "974f81105e246b81ee044d5a0d4e5e84f7c268346bf668afd431f3af712c069e"
+content-hash = "0b2cf2d7f031ec47743d8562c723553bba69c69f2292925b92b558f4c39ebe9e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ tiktoken = "0.4.0"
 beautifulsoup4 = "^4.12.2"
 openai = "^0.27.8"
 langchain = ">=0.0.201,<0.1.0"
-pandas = "^2.0.2"
 pygments = "^2.15.1"
 google-api-python-client = "^2.90.0"
 chispa = "^0.9.2"
@@ -41,4 +40,8 @@ pyspark = "^3.4.0"
 [tool.poetry.group.lint.dependencies]
 flake8 = "^6.0.0"
 black = "^23.7.0"
+
+
+[tool.poetry.group.dev.dependencies]
+pandas = "^2.0.2"
 

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -5,7 +5,13 @@ import re
 from typing import Callable, List, Optional
 from urllib.parse import urlparse
 
-import pandas as pd  # noqa: F401
+# We only try to import pandas here to circumvent certain issues
+# when the generated code assumes that pandas needs to be imported
+# before actually evaluating the code.
+try:
+    import pandas as pd  # noqa: F401
+except ImportError:
+    pass
 import requests
 import tiktoken
 from bs4 import BeautifulSoup


### PR DESCRIPTION
This patch moves the pandas dependency into the `dev` group to only use it for local testing but not for deployment. This can be done because we don't need the dependency locally, but the use can choose to have it. This makes it easier to use Pyspark-ai in conjunction with other packages.