### PR TITLE
Fix backticks error in QueryValidationTool

### DIFF
--- a/examples/window.ipynb
+++ b/examples/window.ipynb
@@ -1,11 +1,19 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "source": [
+    "# Window Example with the Spark SQL ReAct Agent\n",
+    "\n",
+    "From the blog post [Introducing Window Functions in Spark SQL](https://databricks.com/blog/2015/07/15/introducing-window-functions-in-spark-sql.html) by Databricks."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
    "outputs": [
     {
      "name": "stderr",
@@ -22,7 +30,10 @@
     "\n",
     "spark_ai = SparkAI(verbose=True)\n",
     "spark_ai.activate()"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "code",

--- a/examples/window.ipynb
+++ b/examples/window.ipynb
@@ -1,0 +1,256 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Setting default log level to \"WARN\".\n",
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
+      "23/08/09 14:45:34 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark_ai import SparkAI\n",
+    "\n",
+    "spark_ai = SparkAI(verbose=True)\n",
+    "spark_ai.activate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
+   "source": [
+    "spark = spark_ai._spark\n",
+    "# create a dataframe productRevenue\n",
+    "df = spark.createDataFrame(\n",
+    "    [\n",
+    "        (\"Thin\", \"Cellphone\", 6000),\n",
+    "        (\"Normal\", \"Tablet\", 1500),\n",
+    "        (\"Mini\", \"Tablet\", 5500),\n",
+    "        (\"Ultra think\", \"Cellphone\", 5000),\n",
+    "        (\"Very thin\", \"Cellphone\", 6000),\n",
+    "        (\"Big\", \"Tablet\", 2500),\n",
+    "        (\"Bendable\", \"Cellphone\", 3000),\n",
+    "        (\"Foldable\", \"Cellphone\", 3000),\n",
+    "        (\"Pro\", \"Tablet\", 4500),\n",
+    "        (\"Pro2\", \"Tablet\", 6500)\n",
+    "    ],\n",
+    "    [\"product\", \"category\", \"revenue\"]\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001B[92mINFO: \u001B[0mCreating temp view for the transform:\n",
+      "df.createOrReplaceTempView(\u001B[33m\"\u001B[39;49;00m\u001B[33mspark_ai_temp_view_85b651\u001B[39;49;00m\u001B[33m\"\u001B[39;49;00m)\u001B[37m\u001B[39;49;00m\n",
+      "\n",
+      "\n",
+      "\n",
+      "\u001B[1m> Entering new  chain...\u001B[0m\n",
+      "\u001B[32;1m\u001B[1;3mThought: I will use the ROW_NUMBER() function to rank the products in each category by revenue. Then, I will filter the results to only include the top 2 products in each category.\n",
+      "Action: query_validation\n",
+      "Action Input: \n",
+      "```\n",
+      "WITH ranked_products AS (\n",
+      "  SELECT \n",
+      "    product, \n",
+      "    category, \n",
+      "    revenue, \n",
+      "    ROW_NUMBER() OVER(PARTITION BY category ORDER BY revenue DESC) as rank\n",
+      "  FROM spark_ai_temp_view_85b651\n",
+      ")\n",
+      "SELECT product, category, revenue\n",
+      "FROM ranked_products\n",
+      "WHERE rank <= 2\n",
+      "```\u001B[0m\n",
+      "Observation: \u001B[33;1m\u001B[1;3mOK\u001B[0m\n",
+      "Thought:\u001B[32;1m\u001B[1;3mI now know the final answer.\n",
+      "Final Answer: \n",
+      "```\n",
+      "WITH ranked_products AS (\n",
+      "  SELECT \n",
+      "    product, \n",
+      "    category, \n",
+      "    revenue, \n",
+      "    ROW_NUMBER() OVER(PARTITION BY category ORDER BY revenue DESC) as rank\n",
+      "  FROM spark_ai_temp_view_85b651\n",
+      ")\n",
+      "SELECT product, category, revenue\n",
+      "FROM ranked_products\n",
+      "WHERE rank <= 2\n",
+      "```\u001B[0m\n",
+      "\n",
+      "\u001B[1m> Finished chain.\u001B[0m\n",
+      "\u001B[92mINFO: \u001B[0mSQL query:\n",
+      "\u001B[34mWITH\u001B[39;49;00m\u001B[37m \u001B[39;49;00mranked_products\u001B[37m \u001B[39;49;00m\u001B[34mAS\u001B[39;49;00m\u001B[37m \u001B[39;49;00m(\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[37m  \u001B[39;49;00m\u001B[34mSELECT\u001B[39;49;00m\u001B[37m \u001B[39;49;00m\n",
+      "\u001B[37m    \u001B[39;49;00mproduct,\u001B[37m \u001B[39;49;00m\n",
+      "\u001B[37m    \u001B[39;49;00mcategory,\u001B[37m \u001B[39;49;00m\n",
+      "\u001B[37m    \u001B[39;49;00mrevenue,\u001B[37m \u001B[39;49;00m\n",
+      "\u001B[37m    \u001B[39;49;00mROW_NUMBER()\u001B[37m \u001B[39;49;00mOVER(PARTITION\u001B[37m \u001B[39;49;00m\u001B[34mBY\u001B[39;49;00m\u001B[37m \u001B[39;49;00mcategory\u001B[37m \u001B[39;49;00m\u001B[34mORDER\u001B[39;49;00m\u001B[37m \u001B[39;49;00m\u001B[34mBY\u001B[39;49;00m\u001B[37m \u001B[39;49;00mrevenue\u001B[37m \u001B[39;49;00m\u001B[34mDESC\u001B[39;49;00m)\u001B[37m \u001B[39;49;00m\u001B[34mas\u001B[39;49;00m\u001B[37m \u001B[39;49;00mrank\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[37m  \u001B[39;49;00m\u001B[34mFROM\u001B[39;49;00m\u001B[37m \u001B[39;49;00mspark_ai_temp_view_85b651\u001B[37m\u001B[39;49;00m\n",
+      ")\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[34mSELECT\u001B[39;49;00m\u001B[37m \u001B[39;49;00mproduct,\u001B[37m \u001B[39;49;00mcategory,\u001B[37m \u001B[39;49;00mrevenue\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[34mFROM\u001B[39;49;00m\u001B[37m \u001B[39;49;00mranked_products\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[34mWHERE\u001B[39;49;00m\u001B[37m \u001B[39;49;00mrank\u001B[37m \u001B[39;49;00m<=\u001B[37m \u001B[39;49;00m\u001B[34m2\u001B[39;49;00m\u001B[37m\u001B[39;49;00m\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Stage 0:>                                                        (0 + 10) / 10]\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+---------+-------+\n",
+      "|  product| category|revenue|\n",
+      "+---------+---------+-------+\n",
+      "|     Thin|Cellphone|   6000|\n",
+      "|Very thin|Cellphone|   6000|\n",
+      "|     Pro2|   Tablet|   6500|\n",
+      "|     Mini|   Tablet|   5500|\n",
+      "+---------+---------+-------+\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    }
+   ],
+   "source": [
+    "df.ai.transform(\"What are the best-selling and the second best-selling products in every category?\").show()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001B[92mINFO: \u001B[0mCreating temp view for the transform:\n",
+      "df.createOrReplaceTempView(\u001B[33m\"\u001B[39;49;00m\u001B[33mspark_ai_temp_view_5248a4\u001B[39;49;00m\u001B[33m\"\u001B[39;49;00m)\u001B[37m\u001B[39;49;00m\n",
+      "\n",
+      "\n",
+      "\n",
+      "\u001B[1m> Entering new  chain...\u001B[0m\n",
+      "\u001B[32;1m\u001B[1;3mThought: I need to find the maximum revenue for each category first, then subtract the revenue of each product from the maximum revenue of its category.\n",
+      "Action: query_validation\n",
+      "Action Input: \n",
+      "```\n",
+      "WITH max_revenue AS (\n",
+      "  SELECT category, MAX(revenue) as max_revenue\n",
+      "  FROM spark_ai_temp_view_5248a4\n",
+      "  GROUP BY category\n",
+      ")\n",
+      "SELECT a.product, a.category, a.revenue, b.max_revenue - a.revenue as revenue_difference\n",
+      "FROM spark_ai_temp_view_5248a4 a\n",
+      "JOIN max_revenue b\n",
+      "ON a.category = b.category\n",
+      "```\u001B[0m\n",
+      "Observation: \u001B[33;1m\u001B[1;3mOK\u001B[0m\n",
+      "Thought:\u001B[32;1m\u001B[1;3mI now know the final answer.\n",
+      "Final Answer: \n",
+      "```\n",
+      "WITH max_revenue AS (\n",
+      "  SELECT category, MAX(revenue) as max_revenue\n",
+      "  FROM spark_ai_temp_view_5248a4\n",
+      "  GROUP BY category\n",
+      ")\n",
+      "SELECT a.product, a.category, a.revenue, b.max_revenue - a.revenue as revenue_difference\n",
+      "FROM spark_ai_temp_view_5248a4 a\n",
+      "JOIN max_revenue b\n",
+      "ON a.category = b.category\n",
+      "```\u001B[0m\n",
+      "\n",
+      "\u001B[1m> Finished chain.\u001B[0m\n",
+      "\u001B[92mINFO: \u001B[0mSQL query:\n",
+      "\u001B[34mWITH\u001B[39;49;00m\u001B[37m \u001B[39;49;00mmax_revenue\u001B[37m \u001B[39;49;00m\u001B[34mAS\u001B[39;49;00m\u001B[37m \u001B[39;49;00m(\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[37m  \u001B[39;49;00m\u001B[34mSELECT\u001B[39;49;00m\u001B[37m \u001B[39;49;00mcategory,\u001B[37m \u001B[39;49;00m\u001B[34mMAX\u001B[39;49;00m(revenue)\u001B[37m \u001B[39;49;00m\u001B[34mas\u001B[39;49;00m\u001B[37m \u001B[39;49;00mmax_revenue\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[37m  \u001B[39;49;00m\u001B[34mFROM\u001B[39;49;00m\u001B[37m \u001B[39;49;00mspark_ai_temp_view_5248a4\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[37m  \u001B[39;49;00m\u001B[34mGROUP\u001B[39;49;00m\u001B[37m \u001B[39;49;00m\u001B[34mBY\u001B[39;49;00m\u001B[37m \u001B[39;49;00mcategory\u001B[37m\u001B[39;49;00m\n",
+      ")\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[34mSELECT\u001B[39;49;00m\u001B[37m \u001B[39;49;00ma.product,\u001B[37m \u001B[39;49;00ma.category,\u001B[37m \u001B[39;49;00ma.revenue,\u001B[37m \u001B[39;49;00mb.max_revenue\u001B[37m \u001B[39;49;00m-\u001B[37m \u001B[39;49;00ma.revenue\u001B[37m \u001B[39;49;00m\u001B[34mas\u001B[39;49;00m\u001B[37m \u001B[39;49;00mrevenue_difference\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[34mFROM\u001B[39;49;00m\u001B[37m \u001B[39;49;00mspark_ai_temp_view_5248a4\u001B[37m \u001B[39;49;00ma\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[34mJOIN\u001B[39;49;00m\u001B[37m \u001B[39;49;00mmax_revenue\u001B[37m \u001B[39;49;00mb\u001B[37m\u001B[39;49;00m\n",
+      "\u001B[34mON\u001B[39;49;00m\u001B[37m \u001B[39;49;00ma.category\u001B[37m \u001B[39;49;00m=\u001B[37m \u001B[39;49;00mb.category\u001B[37m\u001B[39;49;00m\n",
+      "\n",
+      "+-----------+---------+-------+------------------+\n",
+      "|    product| category|revenue|revenue_difference|\n",
+      "+-----------+---------+-------+------------------+\n",
+      "|       Thin|Cellphone|   6000|                 0|\n",
+      "|     Normal|   Tablet|   1500|              5000|\n",
+      "|       Mini|   Tablet|   5500|              1000|\n",
+      "|Ultra think|Cellphone|   5000|              1000|\n",
+      "|  Very thin|Cellphone|   6000|                 0|\n",
+      "|        Big|   Tablet|   2500|              4000|\n",
+      "|   Bendable|Cellphone|   3000|              3000|\n",
+      "|   Foldable|Cellphone|   3000|              3000|\n",
+      "|        Pro|   Tablet|   4500|              2000|\n",
+      "|       Pro2|   Tablet|   6500|                 0|\n",
+      "+-----------+---------+-------+------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.ai.transform(\"What is the difference between the revenue of each product and the revenue of the best-selling product in the same category of that product?\").show()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/pyspark_ai/ai_utils.py
+++ b/pyspark_ai/ai_utils.py
@@ -1,4 +1,5 @@
-from typing import Optional, Type
+import re
+from typing import Optional, Type, List
 
 from pyspark.sql import DataFrame
 
@@ -106,3 +107,24 @@ class AIUtils:
             A new AIMethodWrapper instance.
         """
         return AIMethodWrapper(self.spark_ai, instance)
+
+    @staticmethod
+    def extract_code_blocks(text) -> List[str]:
+        code_block_pattern = re.compile(r"```(.*?)```", re.DOTALL)
+        code_blocks = re.findall(code_block_pattern, text)
+        if code_blocks:
+            # If there are code blocks, strip them and remove language
+            # specifiers.
+            extracted_blocks = []
+            for block in code_blocks:
+                block = block.strip()
+                if block.startswith("python"):
+                    block = block.replace("python\n", "", 1)
+                elif block.startswith("sql"):
+                    block = block.replace("sql\n", "", 1)
+                extracted_blocks.append(block)
+            return extracted_blocks
+        else:
+            # If there are no code blocks, treat the whole text as a single
+            # block of code.
+            return [text]


### PR DESCRIPTION
The input of the tool `QueryValidationTool` can contain 3 backticks ``` and the tool QueryValidationTool will throw syntax error if the input has 3 backticks
This PR is to fix by using the method `extract_code_blocks` before checking the query. It also introduce a new SQL transform example for the blog https://www.databricks.com/blog/2015/07/15/introducing-window-functions-in-spark-sql.html