### PR TITLE
Aggregate PySpark DataFrame before Pandas conversion

### DIFF
--- a/pyspark_ai/prompt.py
+++ b/pyspark_ai/prompt.py
@@ -175,7 +175,9 @@ Given a pyspark DataFrame `df`, with the output columns:
 
 And an explanation of `df`: {explain}
 
-Write Python code to visualize the result of `df` using plotly. Make sure to use the exact column names of `df`.
+Write Python code to visualize the result of `df` using plotly. Do any aggregation against `df` 
+first, before converting the `df` to a pandas DataFrame. Make sure to use the exact column names 
+of `df`.
 Your code may NOT contain "append" anywhere. Instead of append, use pd.concat.
 There is no need to install any package with pip. Do include any necessary import statements.
 Display the plot directly, instead of saving into an HTML.


### PR DESCRIPTION
## Change
Aggregate the PySpark DataFrame before converting it to a Pandas DataFrame. This helps reduce the likelihood of an OOM error when the PySpark DataFrame is too large to fit into memory.

## Test
Unit test.

A manual run in console is as shown below:
```py
>>> from pyspark_ai import SparkAI
>>> spark_ai = SparkAI(verbose=True)
>>> spark_ai.activate()
>>> df = spark_ai.create_df("https://www.carpro.com/blog/full-year-2022-national-auto-sales-by-brand")
...
>>> root_logger = logging.getLogger()
>>> log_capture_string = StringIO()
>>> ch = logging.StreamHandler(log_capture_string)
>>> root_logger.addHandler(ch)
>>> df.ai.plot("pie chart for US sales market shares, show the top 5 brands and the sum of others")
...
>>> log_contents = log_capture_string.getvalue()
>>> log_contents.find("groupBy")  # groupBy happens before toPandas 
962
>>> log_contents.find("toPandas")
1228


```