### PR TITLE
Add table comment to the prompt of DataFrame transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+spark-warehouse
 vs/
 .vscode/
 .idea/

--- a/pyspark_ai/prompt.py
+++ b/pyspark_ai/prompt.py
@@ -96,7 +96,14 @@ SPARK_SQL_PREFIX = """You are an assistant for writing professional Spark SQL qu
 SPARK_SQL_PROMPT = PromptTemplate.from_examples(
     examples=SPARK_SQL_EXAMPLES,
     suffix=SPARK_SQL_SUFFIX,
-    input_variables=["view_name", "columns", "sample_rows", "comment", "desc", "agent_scratchpad"],
+    input_variables=[
+        "view_name",
+        "columns",
+        "sample_rows",
+        "comment",
+        "desc",
+        "agent_scratchpad",
+    ],
     prefix=SPARK_SQL_PREFIX,
 )
 

--- a/pyspark_ai/prompt.py
+++ b/pyspark_ai/prompt.py
@@ -83,7 +83,8 @@ Thought:I now know the final answer.
 Final Answer: SELECT Name, Age FROM spark_ai_temp_view_wl2sdf WHERE Survived = 1 ORDER BY Age DESC LIMIT 1"""
 ]
 
-SPARK_SQL_SUFFIX = """\nQuestion: Given a Spark temp view `{view_name}` with the following columns:
+SPARK_SQL_SUFFIX = """\nQuestion: Given a Spark temp view `{view_name}` {comment}.
+It contains the following columns:
 ```
 {columns}
 ```
@@ -95,7 +96,7 @@ SPARK_SQL_PREFIX = """You are an assistant for writing professional Spark SQL qu
 SPARK_SQL_PROMPT = PromptTemplate.from_examples(
     examples=SPARK_SQL_EXAMPLES,
     suffix=SPARK_SQL_SUFFIX,
-    input_variables=["view_name", "columns", "sample_rows", "desc", "agent_scratchpad"],
+    input_variables=["view_name", "columns", "sample_rows", "comment", "desc", "agent_scratchpad"],
     prefix=SPARK_SQL_PREFIX,
 )
 

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -354,7 +354,12 @@ class SparkAI:
         return self._create_dataframe_with_llm(page_content, desc, columns, cache)
 
     def _get_transform_sql_query_from_agent(
-        self, temp_view_name: str, schema: str, sample_rows_str: str, comment: str, desc: str
+        self,
+        temp_view_name: str,
+        schema: str,
+        sample_rows_str: str,
+        comment: str,
+        desc: str,
     ) -> str:
         llm_result = self._sql_agent.run(
             view_name=temp_view_name,

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -272,11 +272,12 @@ class SparkAI:
         # The first line is the output schema.
         return "\n".join(splits[begin + 2 : end])
 
-    def _get_tables_from_explain(self, df: DataFrame) -> List[str]:
+    @staticmethod
+    def _get_tables_from_explain(df: DataFrame) -> List[str]:
         """
         Helper function to parse the tables from the content of the explanation
         """
-        explain = self._get_analyzed_plan_from_explain(df)
+        explain = SparkAI._get_analyzed_plan_from_explain(df)
         splits = explain.split("\n")
         # For table relations, the table name is the 2nd element in the line
         # It can be one of the followings:

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -250,7 +250,7 @@ class SparkAI:
         return trimmed_plan
 
     @staticmethod
-    def _parse_explain_string(df: DataFrame) -> str:
+    def _get_analyzed_plan_from_explain(df: DataFrame) -> str:
         """
         Helper function to parse the content of the extended explain
         string to extract the analyzed logical plan. As Spark does not provide
@@ -272,8 +272,29 @@ class SparkAI:
         # The first line is the output schema.
         return "\n".join(splits[begin + 2 : end])
 
+    def _get_tables_from_explain(self, df: DataFrame) -> List[str]:
+        """
+        Helper function to parse the tables from the content of the explanation
+        """
+        explain = self._get_analyzed_plan_from_explain(df)
+        splits = explain.split("\n")
+        # For table relations, the table name is the 2nd element in the line
+        # It can be one of the followings:
+        # 1. "  +- Relation default.foo101"
+        # 2. ":        +- Relation default.foo100"
+        # 3. "Relation default.foo100"
+        tables = []
+        for line in splits:
+            # if line starts with "Relation" or contains "+- Relation", it is a table relation
+            if line.startswith("Relation ") or "+- Relation " in line:
+                table_name_with_output = line.split("Relation ", 1)[1].split(" ")[0]
+                table_name = table_name_with_output.split("[")[0]
+                tables.append(table_name)
+
+        return tables
+
     def _get_df_explain(self, df: DataFrame, cache: bool) -> str:
-        raw_analyzed_str = self._parse_explain_string(df)
+        raw_analyzed_str = self._get_analyzed_plan_from_explain(df)
         tags = self._get_tags(cache)
         return self._explain_chain.run(
             tags=tags, input=self._trim_hash_id(raw_analyzed_str)
@@ -333,12 +354,13 @@ class SparkAI:
         return self._create_dataframe_with_llm(page_content, desc, columns, cache)
 
     def _get_transform_sql_query_from_agent(
-        self, temp_view_name: str, schema: str, sample_rows_str: str, desc: str
+        self, temp_view_name: str, schema: str, sample_rows_str: str, comment: str, desc: str
     ) -> str:
         llm_result = self._sql_agent.run(
             view_name=temp_view_name,
             columns=schema,
             sample_rows=sample_rows_str,
+            comment=comment,
             desc=desc,
         )
         sql_query_from_response = AIUtils.extract_code_blocks(llm_result)[0]
@@ -370,6 +392,25 @@ class SparkAI:
             "*/\n"
         )
 
+    def _get_table_comment_from_desc(self, table_name: str) -> str:
+        try:
+            # Get the output of describe table
+            outputs = self._spark.sql("DESC extended " + table_name).collect()
+            # Get the table comment from output if the first row is "Comment"
+            for row in outputs:
+                if row.col_name == "Comment":
+                    return row.data_type
+        except Exception:
+            # If fail to get table comment, return empty string
+            pass
+
+    def _get_table_comment(self, df: DataFrame) -> str:
+        tables = self._get_tables_from_explain(df)
+        # To be conservative, we return the table comment if there is only one table
+        if len(tables) == 1:
+            return "which represents " + self._get_table_comment_from_desc(tables[0])
+        return ""
+
     def _get_transform_sql_query(self, df: DataFrame, desc: str, cache: bool) -> str:
         temp_view_name = random_view_name()
         create_temp_view_code = CodeLogger.colorize_code(
@@ -379,6 +420,7 @@ class SparkAI:
         df.createOrReplaceTempView(temp_view_name)
         schema_str = self._get_df_schema(df)
         sample_rows_str = self._get_sample_spark_rows(df, temp_view_name)
+        comment = self._get_table_comment(df)
 
         if cache:
             cache_key = ReActSparkSQLAgent.cache_key(desc, schema_str)
@@ -389,13 +431,13 @@ class SparkAI:
                 return replace_view_name(cached_result, temp_view_name)
             else:
                 sql_query = self._get_transform_sql_query_from_agent(
-                    temp_view_name, schema_str, sample_rows_str, desc
+                    temp_view_name, schema_str, sample_rows_str, comment, desc
                 )
                 self._cache.update(key=cache_key, val=canonize_string(sql_query))
                 return sql_query
         else:
             return self._get_transform_sql_query_from_agent(
-                temp_view_name, schema_str, sample_rows_str, desc
+                temp_view_name, schema_str, sample_rows_str, comment, desc
             )
 
     def transform_df(self, df: DataFrame, desc: str, cache: bool = True) -> DataFrame:

--- a/tests/test_spark_ai.py
+++ b/tests/test_spark_ai.py
@@ -37,26 +37,32 @@ class SparkAIInitializationTestCase(unittest.TestCase):
         self.assertEqual(self.spark_ai._max_tokens_of_web_content, 3000)
 
 
-class TestGetTablesFromExplain(unittest.TestCase):
+class TestGetTableCommentFromExplain(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         cls.spark = SparkSession.builder.getOrCreate()
+        cls.llm_mock = MagicMock(spec=BaseLanguageModel)
+        cls.spark_ai = SparkAI(llm=cls.llm_mock, spark_session=cls.spark)
 
     @classmethod
     def tearDownClass(cls):
         cls.spark.stop()
 
-    def create_and_read_table(self, table_name, data):
+    def create_and_read_table(self, table_name, data, comment=''):
         self.spark.createDataFrame(data, ["col1", "col2"]).write.saveAsTable(table_name)
+        if comment != '':
+            self.spark.sql(f"ALTER TABLE {table_name} SET TBLPROPERTIES ('comment' = '{comment}')")
         return self.spark.sql(f"SELECT * FROM {table_name}")
 
     def test_single_table(self):
         table_name = "spark_catalog.default.test_table1"
+        comment = "comment1"
         try:
-            df = self.create_and_read_table(table_name, [(1, "foo"), (2, "bar")])
+            df = self.create_and_read_table(table_name, [(1, "foo"), (2, "bar")], comment)
             tables = SparkAI._get_tables_from_explain(df)
             self.assertEqual(tables, [table_name])
+            self.assertEqual(self.spark_ai._get_table_comment(df), "which represents comment1")
         finally:
             self.spark.sql(f"DROP TABLE IF EXISTS {table_name}")
 
@@ -67,6 +73,8 @@ class TestGetTablesFromExplain(unittest.TestCase):
             df = dfs[0].join(dfs[1], "col1")
             tables = SparkAI._get_tables_from_explain(df)
             self.assertEqual(tables, table_names)
+            # Currently we only set the comment when reading a single table
+            self.assertEqual(self.spark_ai._get_table_comment(df), "")
         finally:
             for name in table_names:
                 self.spark.sql(f"DROP TABLE IF EXISTS {name}")
@@ -75,6 +83,7 @@ class TestGetTablesFromExplain(unittest.TestCase):
         df = self.spark.createDataFrame([(1, "foo"), (2, "bar")], ["col1", "col2"])
         tables = SparkAI._get_tables_from_explain(df)
         self.assertEqual(tables, [])
+        self.assertEqual(self.spark_ai._get_table_comment(df), "")
 
 class SparkAITrimTextTestCase(unittest.TestCase):
     """Test cases for the _trim_text_from_end method of the SparkAI."""

--- a/tests/test_spark_ai.py
+++ b/tests/test_spark_ai.py
@@ -202,7 +202,7 @@ class SparkAnalysisTest(SparkTestCase):
     def test_analysis_handling(self):
         self.spark_ai = SparkAI(llm=self.llm_mock)
         df = self.spark.range(100).groupBy("id").count()
-        left = self.spark_ai._parse_explain_string(df)
+        left = self.spark_ai._get_analyzed_plan_from_explain(df)
         right = df._jdf.queryExecution().analyzed().toString()
         self.assertEqual(left, right)
 


### PR DESCRIPTION
For the `df.ai.transform` method, if the input dataframe is reading from a single table, include the table comment into the prompt can help the accuracy of generated SQL.
Before the changes, the following WikiSQL tests
```
{"phase": 1, "table_id": "1-1004033-1", "question": "When did the Metrostars have their first Rookie of the Year winner?", "sql": {"sel": 0, "conds": [[4, 0, "MetroStars"]], "agg": 2}, "result": [2001.0], "query": "SELECT MIN(col0) AS result FROM table_1_1004033_1 WHERE col4 = 'metrostars'"}
{"phase": 1, "table_id": "1-1004033-1", "question": "What college did the Rookie of the Year from the Columbus Crew attend?", "sql": {"sel": 7, "conds": [[4, 0, "Columbus Crew"]], "agg": 0}, "result": ["virginia"], "query": "SELECT col7 AS result FROM table_1_1004033_1 WHERE col4 = 'columbus crew'"}
{"phase": 1, "table_id": "1-1004033-1", "question": "How many teams had a #1 draft pick that won the Rookie of the Year Award?", "sql": {"sel": 4, "conds": [[5, 0, "1"]], "agg": 3}, "result": [1], "query": "SELECT COUNT(col4) AS result FROM table_1_1004033_1 WHERE col5 = '1'"}
```
will failed:
```
Question: When did the Metrostars have their first Rookie of the Year winner?
Expected query: SELECT `MIN(Season)` FROM `1-1004033-1` WHERE `Team` = 'metrostars'
Actual query: select season from spark_ai_temp_view_f554c8 where team = 'metrostars' and player like '%rookie of the year%' order by season asc limit 1
Expected result: [2001.0]
Actual result: []

Question: What college did the Rookie of the Year from the Columbus Crew attend?
Expected query: SELECT `(College)` FROM `1-1004033-1` WHERE `Team` = 'columbus crew'
Actual query: select college from spark_ai_temp_view_4372d6 where team = 'columbus crew' and `draft class` = 'rookie of the year'
Expected result: ['virginia']
Actual result: []

The question does not provide enough information to write a query. The table does not have a column indicating whether a player won the Rookie of the Year Award.
```

With the prompt, all tests passed. 
