### PR TITLE
Add similarity wikisql function, fix prompt for COUNT examples

### DIFF
--- a/benchmark/wikisql/wiki_sql.py
+++ b/benchmark/wikisql/wiki_sql.py
@@ -111,8 +111,8 @@ def similarity(spark_ai_result, expected_result):
 
 if __name__ == '__main__':
     parser = ArgumentParser()
-    parser.add_argument('--table_file', help='table definition file', default='data/test_sample1.tables1.jsonl')
-    parser.add_argument('--source_file', help='source file for the prediction', default='data/test_sample1.jsonl')
+    parser.add_argument('--table_file', help='table definition file', default='data/test_sample.tables.jsonl')
+    parser.add_argument('--source_file', help='source file for the prediction', default='data/test_sample.jsonl')
     args = parser.parse_args()
 
     table_file = args.table_file

--- a/benchmark/wikisql/wiki_sql.py
+++ b/benchmark/wikisql/wiki_sql.py
@@ -53,7 +53,6 @@ def create_temp_view_statements(table_file):
                 page_title = ''
             comment = section_title + page_title
             create_statement = f"CREATE TABLE IF NOT EXISTS `{table_name}` USING ORC comment \"{comment}\" AS SELECT * FROM VALUES {values_str} as {header_str};"
-            # print("*** create statement ***", create_statement)
             sql_statements.append(create_statement)
 
     return sql_statements

--- a/pyspark_ai/prompt.py
+++ b/pyspark_ai/prompt.py
@@ -67,7 +67,7 @@ Make STRING
 ```
 Write a Spark SQL query to retrieve from view `spark_ai_temp_view_19acs2`: If color is gold, what is the total number of cars?
 Thought: I will use the column 'Color' to filter the rows where its value is 'gold' and then select the COUNT(`Car`) 
-because COUNT gives me the total number of cars. I do not use SUM because SUM is not for counting total number.
+because COUNT gives me the total number of cars.
 Action: query_validation
 Action Input: SELECT COUNT(`Car`) FROM spark_ai_temp_view_19acs2 WHERE `Color` = 'gold'
 Observation: OK
@@ -101,10 +101,10 @@ SPARK_SQL_SUFFIX = """\nQuestion: Given a Spark temp view `{view_name}` {comment
 The dataframe contains the column names and types in this format:
 column_name: type.
 It's very important to ONLY use the verbatim column names in your resulting SQL query.
-For example, the verbatim column name from the line 'Fruit Color: string' is 'Fruit Color'.
-So, a resulting SQL query would be: SELECT * FROM view WHERE 'Fruit Color' = 'orange'.
-The verbatim column name from the line 'Number of years: int' is 'Number of years'.
-So, a resulting SQL query would be: SELECT * FROM view WHERE 'Number of years' = 3.
+For example, the verbatim column name from the line 'Fruit Color: string' is `Fruit Color`.
+So, a resulting SQL query would be: SELECT * FROM view WHERE `Fruit Color` = 'orange'.
+The verbatim column name from the line 'Number of years: int' is `Number of years`.
+So, a resulting SQL query would be: SELECT * FROM view WHERE `Number of years` = 3.
 
 Here are the column names and types for your dataframe:
 ```
@@ -119,7 +119,7 @@ Write a Spark SQL query to retrieve the following from view `{view_name}`: {desc
 
 SPARK_SQL_PREFIX = """You are an assistant for writing professional Spark SQL queries. 
 Given a question, you need to write a Spark SQL query to answer the question. The result is ALWAYS a Spark SQL query.
-If the question contains 'total number', use the SQL function COUNT(column_name) on the relevant column(s), NOT the SUM function."""
+If the question contains 'total number', use the SQL function COUNT(column_name) on the relevant column(s)."""
 
 SPARK_SQL_PROMPT = PromptTemplate.from_examples(
     examples=SPARK_SQL_EXAMPLES,

--- a/pyspark_ai/prompt.py
+++ b/pyspark_ai/prompt.py
@@ -59,6 +59,20 @@ Action Input: SELECT * FROM spark_ai_temp_view_93bcf0 PIVOT (SUM(Amount) FOR Cou
 Observation: OK
 Thought:I now know the final answer.
 Final Answer: SELECT * FROM spark_ai_temp_view_93bcf0 PIVOT (SUM(Amount) FOR Country IN ('USA', 'Canada', 'Mexico', 'China'))"""
+    """QUESTION: Given a Spark temp view `spark_ai_temp_view_19acs2` with the following columns:
+```
+Car STRING
+Color STRING
+Make STRING
+```
+Write a Spark SQL query to retrieve from view `spark_ai_temp_view_19acs2`: If color is gold, what is the total number of cars?
+Thought: I will use the column 'Color' to filter the rows where its value is 'gold' and then select the COUNT(`Car`) 
+because COUNT gives me the total number of cars. I do not use SUM because SUM is not for counting total number.
+Action: query_validation
+Action Input: SELECT COUNT(`Car`) FROM spark_ai_temp_view_19acs2 WHERE `Color` = 'gold'
+Observation: OK
+Thought: I now know the final answer.
+Final Answer: SELECT COUNT(`Car`) FROM spark_ai_temp_view_19acs2 WHERE `Color` = 'gold'"""
     """QUESTION: Given a Spark temp view `spark_ai_temp_view_wl2sdf` with the following columns:
 ```
 PassengerId INT
@@ -84,15 +98,29 @@ Final Answer: SELECT Name, Age FROM spark_ai_temp_view_wl2sdf WHERE Survived = 1
 ]
 
 SPARK_SQL_SUFFIX = """\nQuestion: Given a Spark temp view `{view_name}` {comment}.
-It contains the following columns:
+The dataframe contains the column names and types in this format:
+column_name: type.
+It's very important to ONLY use the verbatim column names in your resulting SQL query.
+For example, the verbatim column name from the line 'Fruit Color: string' is 'Fruit Color'.
+So, a resulting SQL query would be: SELECT * FROM view WHERE 'Fruit Color' = 'orange'.
+The verbatim column name from the line 'Number of years: int' is 'Number of years'.
+So, a resulting SQL query would be: SELECT * FROM view WHERE 'Number of years' = 3.
+
+Here are the column names and types for your dataframe:
 ```
 {columns}
 ```
+
+Here are some sample rows from your dataframe:
 {sample_rows}
-Write a Spark SQL query to retrieve from view `{view_name}`: {desc}
+
+Write a Spark SQL query to retrieve the following from view `{view_name}`: {desc}
 {agent_scratchpad}"""
 
-SPARK_SQL_PREFIX = """You are an assistant for writing professional Spark SQL queries. Given a question, you need to write a Spark SQL query to answer the question. The result is ALWAYS a Spark SQL query."""
+SPARK_SQL_PREFIX = """You are an assistant for writing professional Spark SQL queries. 
+Given a question, you need to write a Spark SQL query to answer the question. The result is ALWAYS a Spark SQL query.
+If the question contains 'total number', use the SQL function COUNT(column_name) on the relevant column(s), NOT the SUM function."""
+
 SPARK_SQL_PROMPT = PromptTemplate.from_examples(
     examples=SPARK_SQL_EXAMPLES,
     suffix=SPARK_SQL_SUFFIX,

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -130,6 +130,12 @@ class SparkAI:
         return AgentExecutor.from_agent_and_tools(
             agent=agent, tools=tools, verbose=True
         )
+        # agent = ReActSparkSQLAgent.from_llm_and_tools(
+        #     llm=self._llm, tools=tools, verbose=True
+        # )
+        # return AgentExecutor.from_agent_and_tools(
+        #     agent=agent, tools=tools, verbose=True
+        # )
 
     @staticmethod
     def _extract_view_name(query: str) -> str:
@@ -369,6 +375,7 @@ class SparkAI:
             comment=comment,
             desc=desc,
         )
+        print("*** schema ***", schema)
         sql_query_from_response = AIUtils.extract_code_blocks(llm_result)[0]
         return sql_query_from_response
 
@@ -406,7 +413,7 @@ class SparkAI:
             for row in outputs:
                 if row.col_name == "Comment":
                     return row.data_type
-        except Exception:
+        except Exception as e:
             # If fail to get table comment, return empty string
             pass
 

--- a/pyspark_ai/pyspark_ai.py
+++ b/pyspark_ai/pyspark_ai.py
@@ -130,12 +130,6 @@ class SparkAI:
         return AgentExecutor.from_agent_and_tools(
             agent=agent, tools=tools, verbose=True
         )
-        # agent = ReActSparkSQLAgent.from_llm_and_tools(
-        #     llm=self._llm, tools=tools, verbose=True
-        # )
-        # return AgentExecutor.from_agent_and_tools(
-        #     agent=agent, tools=tools, verbose=True
-        # )
 
     @staticmethod
     def _extract_view_name(query: str) -> str:
@@ -375,7 +369,6 @@ class SparkAI:
             comment=comment,
             desc=desc,
         )
-        print("*** schema ***", schema)
         sql_query_from_response = AIUtils.extract_code_blocks(llm_result)[0]
         return sql_query_from_response
 
@@ -413,7 +406,7 @@ class SparkAI:
             for row in outputs:
                 if row.col_name == "Comment":
                     return row.data_type
-        except Exception as e:
+        except Exception:
             # If fail to get table comment, return empty string
             pass
 


### PR DESCRIPTION
This PR adds a similarity function that uses the spacy library to calculate semantic similarity between string results. This is used in evaluating accuracy of results when run on the wikisql dataset.

The PR also makes modifications to fix examples that use COUNT, such as the following questions (no longer fail):
```
Question: what's the total number of south australia with victoria value of 2173
Question: what is the total number of ties played where total w–l is 38–24
Question: what is the total number of singles w–l where doubles w–l is 11–14
```

The PR also accounts for different orderings of result lists, such as the following question (no longer fail):
```
Which wrestlers have had 2 reigns?
Expected result: ['roderick strong', 'davey richards', 'erick stevens']
Actual result: ['roderick strong', 'erick stevens', 'davey richards']
```
